### PR TITLE
zeek: Switch to built-in telemetry

### DIFF
--- a/containers/grafana/dashboards/ZeekLogs.json
+++ b/containers/grafana/dashboards/ZeekLogs.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -78,7 +78,7 @@
         "x": 0,
         "y": 8
       },
-      "id": 6,
+      "id": 7,
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": true,
@@ -96,12 +96,12 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "editorMode": "code",
-          "expr": "{filename=\"/var/zeek/logs/http.log\"} |  json | line_format `{{ .id_orig_h }} ({{ .user_agent }}) {{ .method }} {{ .host }}{{.uri}}. Response: {{ .status_code }} {{ .status_msg }}`",
+          "expr": "{filename=\"/var/zeek/logs/ssl.log\"} |  json | line_format `{{ .id_orig_h }} -> {{ .id_resp_h }}:{{ .id_resp_p }}: {{ .server_name }} {{ .ssl_history }} {{ .version }} {{ .cipher }}`",
           "queryType": "range",
           "refId": "A"
         }
       ],
-      "title": "http.log",
+      "title": "ssl.log",
       "type": "logs"
     },
     {

--- a/containers/grafana/dashboards/ZeekTelemetry.json
+++ b/containers/grafana/dashboards/ZeekTelemetry.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -343,7 +343,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "rate(zeek_bytes_received_total[$__rate_interval])",
+          "expr": "rate(zeek_net_received_bytes_total[$__rate_interval])",
           "legendFormat": "bytes received",
           "range": true,
           "refId": "A"
@@ -354,7 +354,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "rate(zeek_packets_received_total[$__rate_interval])",
+          "expr": "rate(zeek_net_received_packets_total[$__rate_interval])",
           "hide": false,
           "legendFormat": "packets received",
           "range": true,
@@ -366,7 +366,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "rate(zeek_packets_dropped_total[$__rate_interval])",
+          "expr": "rate(zeek_net_dropped_packets_total[$__rate_interval])",
           "hide": false,
           "legendFormat": "packets dropped",
           "range": true,
@@ -458,10 +458,12 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(zeek_log_writes_total{}[$__interval])",
+          "expr": "rate(zeek_log_stream_writes_total{}[$__interval])",
           "interval": "",
-          "legendFormat": "{{ log_id }}",
+          "legendFormat": "{{ stream }}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -963,6 +965,6 @@
   "timezone": "",
   "title": "Zeek Telemetry",
   "uid": "kww9S-h4k",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/containers/zeek/local.zeek
+++ b/containers/zeek/local.zeek
@@ -10,4 +10,7 @@ redef LogAscii::use_json=T;
 
 @load misc/loaded-scripts
 
+# This enables the zeek_net_ metrics.
+@load misc/stats
+
 @load ./scripts/telemetry


### PR DESCRIPTION
Log stream writes, event handler invocations and network statistics are now native to Zeek. Switch to them.